### PR TITLE
Use facter to detect and install python 3.9.2 if not present

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,16 +26,16 @@ class wpython::install inherits wpython {
     #installs 3.5+, it matters since python now uses .exe instead of .msi
     package {'python35':
       ensure          => installed,
-      source          => "C:/pythonfiles/python-${version}.exe",
+      source          => "${downloaddirectory}/python-${version}.exe",
       provider        => windows,
-      install_options => ['/quiet', { 'InstallAllUsers' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
+      install_options => ['/quiet', { 'InstallAllUsers' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, { 'PrependPath' => '1' }, ],
       }
     }
     
     else {
       package {"Python ${version} (32-bit)":
         ensure            => absent,
-        source            => "C:/pythonfiles/python-${version}.exe",
+        source            => "${downloaddirectory}/python-${version}.exe",
         provider          => windows,
         uninstall_options => ['/uninstall', '/quiet'],
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,29 +9,38 @@ class wpython::install inherits wpython {
   if versioncmp('3.5', $version) <= 0{
     
     if $uninstall != true {
+ 
+	# creates directory for downloads 
+    	file {'pythondirectory':
+    	  ensure => directory,    
+    	  path   => "${downloaddirectory}",
+    	}
   
-    file {'pythondirectory':
-      ensure => directory,    
-      path   => "${downloaddirectory}",
-    }
-  
-    #package resource for windows exes only support file system URIs, hence need to store a copy
-    file {'pythondownload':
-      ensure => present,
-      path   => "${downloaddirectory}/python-${version}.exe",
-      source => "https://www.python.org/ftp/python/${version}/python-${version}.exe",
-    }
+    	#package resource for windows exes only support file system URIs, hence need to store a copy
+    	file {'pythondownload':
+    	  ensure => present,
+    	  path   => "${downloaddirectory}/python-${version}.exe",
+    	  source => "https://www.python.org/ftp/python/${version}/python-${version}.exe",
+    	}
 
-    #/i & /qn flags are automatically included.
-    #installs 3.5+, it matters since python now uses .exe instead of .msi
-    package {'python35':
-      ensure          => installed,
-      source          => "${downloaddirectory}/python-${version}.exe",
-      provider        => windows,
-      install_options => ['/quiet', { 'InstallAllUsers' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, { 'PrependPath' => '1' }, ],
-      }
+	#________________________________________________________________ If python installed, If not installed...
+    	if $facts['python_version'] == '3.9.2' {
+    	  notify {'Python is installed with version 3.9.2' :}
+    	}
+    	else {
+    	  #/i & /qn flags are automatically included.
+    	  #installs 3.5+, it matters since python now uses .exe instead of .msi
+    	  notify {'Python 3.9.2 not present, installing...':}
+    	  package {'python35':
+    	    ensure          => installed,
+    	    source          => "${downloaddirectory}/python-${version}.exe",
+    	    provider        => windows,
+    	    install_options => ['/quiet', { 'InstallAllUsers' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, { 'PrependPath' => '1' }, ],
+    	   }
+    	}
+
     }
-    
+    #____________________________________________________________________ If uninstall option 
     else {
       package {"Python ${version} (32-bit)":
         ensure            => absent,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class wpython::install inherits wpython {
     	}
 
 	#________________________________________________________________ If python installed, If not installed...
-    	if $facts['python_version'] == '3.9.2' {
+    	if $facts['python_version'] == '3.9.2' and $facts['python_release'] == "3.9" {
     	  notify {'Python is installed with version 3.9.2' :}
     	}
     	else {
@@ -51,51 +51,50 @@ class wpython::install inherits wpython {
     }
     
   }
-  
-  #Yes, that is how it's spelled
-  elsif versioncmp('3.0', $version) <=0{
-  
-    if $uninstall != true {
-    
-      #installs 3.0+
-      package {'python30':
-        ensure          => installed,
-        source          => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
-        provider        => windows,
-        install_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
-        }
-    }
-    
-    else {
-    
-      package {"Python ${version}":
-        ensure            => absent,
-        source            => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
-        provider          => windows,
-        uninstall_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
-        }
-    }
-  }
-  
-  else {
-    
-    if $uninstall != true {
-      #install 2.7
-      package {'python27':
-        ensure          => installed,
-        source          => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
-        provider        => windows,
-        install_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
-        }
-      }
-    else {
-      package {"Python ${version}":
-        ensure            => absent,
-        source            => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
-        provider          => windows,
-        uninstall_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
-        }
-    }
-  }
+ } 
+ # #Yes, that is how it's spelled
+ # elsif versioncmp('3.0', $version) <=0{
+ # 
+ #   if $uninstall != true {
+ #   
+ #     #installs 3.0+
+ #     package {'python30':
+ #       ensure          => installed,
+ #       source          => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
+ #       provider        => windows,
+ #       install_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
+ #       }
+ #   }
+ #   
+ #   else {
+ #   
+ #     package {"Python ${version}":
+ #       ensure            => absent,
+ #       source            => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
+ #       provider          => windows,
+ #       uninstall_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
+ #       }
+ #   }
+ # }
+ # 
+ # else {
+ #   
+ #   if $uninstall != true {
+ #     #install 2.7
+ #     package {'python27':
+ #       ensure          => installed,
+ #       source          => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
+ #       provider        => windows,
+ #       install_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
+ #       }
+ #     }
+ #   else {
+ #     package {"Python ${version}":
+ #       ensure            => absent,
+ #       source            => "https://www.python.org/ftp/python/${version}/python-${version}.msi",
+ #       provider          => windows,
+ #       uninstall_options => [{ 'ALLUSERS' => '1' }, { 'IACCEPTSQLNCLILICENSETERMS' => 'YES' }, ],
+ #       }
+ #   }
+ # }
 
-}


### PR DESCRIPTION
In this fix I've modified the manifest in order to install python 3.9.2 evaluating with Facter if it is installed or not. If the key,value of the Facter  `"python_version": "3.9.2"`, isn't present when executing `puppet facts `(in the windows host), the installer is executed.

I've also added in the install options` { 'PrependPath' => '1' }`  so `$PATH` for python is included in windows. In this way you could call `python` from `cmd`.

Because I'm only focused on installing python 3.9.2, I won't fix the elif for other versions, but left them commented at the end of the file.

There are more things to make this module better, but this worked for me. 